### PR TITLE
feat: add zendesk-tickets table

### DIFF
--- a/migrations/2019-09-08-020036_zendesk_tickets/down.sql
+++ b/migrations/2019-09-08-020036_zendesk_tickets/down.sql
@@ -1,2 +1,2 @@
 -- This file should undo anything in `up.sql`
-DROP TABLE zendesk_tickets;
+DROP TABLE solidarity_zd_tickets;

--- a/migrations/2019-09-08-020036_zendesk_tickets/down.sql
+++ b/migrations/2019-09-08-020036_zendesk_tickets/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+DROP TABLE zendesk_tickets;

--- a/migrations/2019-09-08-020036_zendesk_tickets/up.sql
+++ b/migrations/2019-09-08-020036_zendesk_tickets/up.sql
@@ -1,5 +1,5 @@
 -- Your SQL goes here
-CREATE TABLE zendesk_tickets (
+CREATE TABLE solidarity_zd_tickets (
     id SERIAL PRIMARY KEY,
     assignee_id BIGINT,
     created_at TIMESTAMP,
@@ -14,5 +14,16 @@ CREATE TABLE zendesk_tickets (
     subject TEXT,
     submitter_id BIGINT,
     tags JSONB,
-    updated_at TIMESTAMP
+    updated_at TIMESTAMP,
+    status_acolhimento TEXT,
+    nome_voluntaria TEXT,
+    link_match TEXT,
+    nome_msr TEXT,
+    data_inscricao_bonde TIMESTAMP,
+    data_encaminhamento TIMESTAMP,
+    status_inscricao TEXT,
+    telefone TEXT,
+    estado TEXT,
+    cidade TEXT,
+    community_id BIGINT
 );

--- a/migrations/2019-09-08-020036_zendesk_tickets/up.sql
+++ b/migrations/2019-09-08-020036_zendesk_tickets/up.sql
@@ -1,0 +1,18 @@
+-- Your SQL goes here
+CREATE TABLE zendesk_tickets (
+    id SERIAL PRIMARY KEY,
+    assignee_id BIGINT,
+    created_at TIMESTAMP,
+    custom_fields JSONB,
+    description TEXT,
+    group_id BIGINT,
+    ticket_id BIGINT UNIQUE NOT NULL,
+    organization_id BIGINT,
+    raw_subject TEXT,
+    requester_id BIGINT,
+    status TEXT,
+    subject TEXT,
+    submitter_id BIGINT,
+    tags JSONB,
+    updated_at TIMESTAMP
+);


### PR DESCRIPTION
#### Contexto
Cria as migrations para a tabela de tickets do banco de dados. É parte necessária para a integração dos tickets do zendesk na plataforma.

##### Em andamento
- [ ] Criação de campos dos tickets para os custom_fields.