### PR TITLE
fix: solidarity-matches

### DIFF
--- a/migrations/2019-10-28-205224_solidarity_matches_change_constraints/down.sql
+++ b/migrations/2019-10-28-205224_solidarity_matches_change_constraints/down.sql
@@ -1,0 +1,5 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE solidarity_matches DROP CONSTRAINT solidarity_matches_individuals_ticket_id_volunteers_ticket__key;
+ALTER TABLE solidarity_matches ADD UNIQUE (individuals_user_id, volunteers_user_id);
+ALTER TABLE solidarity_matches ADD UNIQUE (individuals_ticket_id);
+ALTER TABLE solidarity_matches ADD UNIQUE (volunteers_ticket_id);

--- a/migrations/2019-10-28-205224_solidarity_matches_change_constraints/up.sql
+++ b/migrations/2019-10-28-205224_solidarity_matches_change_constraints/up.sql
@@ -1,0 +1,5 @@
+-- Your SQL goes here-- Your SQL goes here
+ALTER TABLE solidarity_matches DROP CONSTRAINT solidarity_matches_individuals_user_id_volunteers_user_id_key;
+ALTER TABLE solidarity_matches DROP CONSTRAINT solidarity_matches_individuals_ticket_id_key;
+ALTER TABLE solidarity_matches DROP CONSTRAINT solidarity_matches_volunteers_ticket_id_key;
+ALTER TABLE solidarity_matches ADD UNIQUE (individuals_ticket_id, volunteers_ticket_id);


### PR DESCRIPTION
#### Contexto

Esse PR resolve o problema de INSERT do solidarity-matches.
Lembrar de dar "RELOAD" no metadata, do contrário, o Hasura continuará tentando inserir com o nome da constraint anterior.