### PR TITLE
Add settings columns to rede_groups table

### DIFF
--- a/migrations/2020-10-26-231351_groups_settings/down.sql
+++ b/migrations/2020-10-26-231351_groups_settings/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE rede_groups DROP COLUMN settings; 

--- a/migrations/2020-10-26-231351_groups_settings/up.sql
+++ b/migrations/2020-10-26-231351_groups_settings/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE rede_groups ADD COLUMN settings jsonb NOT NULL default '{}'::jsonb


### PR DESCRIPTION
This was added so we could consult each rede_group setting, like communication messages.